### PR TITLE
added the missing "certificate" parameter in the "SetWebhook"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Telegram Bot API for PHP Change Log
 
-## 0.19 April 4, 2026
+## 0.18.1 April 5, 2026
 
 - Bug #192: Add missed `certificate` parameter to `SetWebhook` method.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Telegram Bot API for PHP Change Log
 
+## 0.19 April 4, 2026
+
+- New #192: Add `certificate` constructor parameter to `SetWebhook` class and add `certificate` field to `TelegramBotApi::setWebhook()` method.
+
 ## 0.18 April 4, 2026
 
 - Enh #190: Open file in binary mode in `InputFile::fromLocalFile()` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.19 April 4, 2026
 
-- New #192: Add `certificate` constructor parameter to `SetWebhook` class and add `certificate` field to `TelegramBotApi::setWebhook()` method.
+- Bug #192: Add missed `certificate` parameter to `SetWebhook` method.
 
 ## 0.18 April 4, 2026
 

--- a/src/Method/Update/SetWebhook.php
+++ b/src/Method/Update/SetWebhook.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phptg\BotApi\Method\Update;
 
+use Phptg\BotApi\Type\InputFile;
 use SensitiveParameter;
 use Phptg\BotApi\ParseResult\ValueProcessor\TrueValue;
 use Phptg\BotApi\Transport\HttpMethod;
@@ -24,6 +25,7 @@ final readonly class SetWebhook implements MethodInterface
         private ?bool $dropPendingUpdates = null,
         #[SensitiveParameter]
         private ?string $secretToken = null,
+        private ?InputFile $certificate = null,
     ) {}
 
     public function getHttpMethod(): HttpMethod
@@ -46,6 +48,7 @@ final readonly class SetWebhook implements MethodInterface
                 'allowed_updates' => $this->allowUpdates,
                 'drop_pending_updates' => $this->dropPendingUpdates,
                 'secret_token' => $this->secretToken,
+                'certificate' => $this->certificate,
             ],
             static fn(mixed $value): bool => $value !== null,
         );

--- a/src/TelegramBotApi.php
+++ b/src/TelegramBotApi.php
@@ -3169,9 +3169,10 @@ final class TelegramBotApi
         ?bool $dropPendingUpdates = null,
         #[SensitiveParameter]
         ?string $secretToken = null,
+        ?InputFile $certificate = null,
     ): FailResult|true {
         return $this->call(
-            new SetWebhook($url, $ipAddress, $maxConnections, $allowUpdates, $dropPendingUpdates, $secretToken),
+            new SetWebhook($url, $ipAddress, $maxConnections, $allowUpdates, $dropPendingUpdates, $secretToken, $certificate),
         );
     }
 

--- a/tests/Method/Update/SetWebhookTest.php
+++ b/tests/Method/Update/SetWebhookTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phptg\BotApi\Tests\Method\Update;
 
+use Phptg\BotApi\Type\InputFile;
 use PHPUnit\Framework\TestCase;
 use Phptg\BotApi\Transport\HttpMethod;
 use Phptg\BotApi\Method\Update\SetWebhook;
@@ -30,6 +31,7 @@ final class SetWebhookTest extends TestCase
 
     public function testFull(): void
     {
+        $file = new InputFile(null);
         $method = new SetWebhook(
             'https://example.com/hook',
             '127.0.0.1',
@@ -37,6 +39,7 @@ final class SetWebhookTest extends TestCase
             ['update1', 'update2'],
             true,
             'asdg23y',
+            $file,
         );
 
         assertSame(HttpMethod::POST, $method->getHttpMethod());
@@ -49,6 +52,7 @@ final class SetWebhookTest extends TestCase
                 'allowed_updates' => ['update1', 'update2'],
                 'drop_pending_updates' => true,
                 'secret_token' => 'asdg23y',
+                'certificate' => $file,
             ],
             $method->getData(),
         );


### PR DESCRIPTION
The "certificate" parameter is currently missing in the "SetWebhook" method.
This pull request fixes this issue.

https://core.telegram.org/bots/api#setwebhook